### PR TITLE
fix: now copy click works with all inputs (#3)

### DIFF
--- a/components/ShareCard.vue
+++ b/components/ShareCard.vue
@@ -24,7 +24,7 @@
     </div>
     <div class="share-card__link-container">
       <input
-        id="result"
+        ref="inputResult"
         class="code-block"
         placeholder="// result"
         :value="link ? result : ''"
@@ -73,7 +73,7 @@ export default {
     },
     copyLink() {
       if (process.client) {
-        const res = document.querySelector("#result");
+        const res = this.$refs.inputResult;
         if (!this.hasCopied && res.value) {
           const value = res.value;
           res.select();


### PR DESCRIPTION
Fixes #3 

----

I've just renamed `"id"` to `"ref"` and call it as `this.$refs.inputResult.select()`